### PR TITLE
Workaround for Alpine Linux on Kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,6 @@ FROM runatlantis/atlantis:v0.16.1
 
 USER ROOT
 CMD apk add jq postgresql-client
+# Workaround for Alpine Linux on Kubernetes
+CMD cat /etc/resolv.conf | sed -r "s/^(search.*|options.*)/#\1/" > /tmp/resolv && cat /tmp/resolv > /etc/resolv.conf
 USER atlantis


### PR DESCRIPTION
This removes the search and option from resolv.conf, which are not
handled weel by musl libc implementation.